### PR TITLE
RFP

### DIFF
--- a/4k.c
+++ b/4k.c
@@ -555,14 +555,15 @@ static i32 search(Position *const pos, const i32 ply, i32 depth, i32 alpha,
   const bool in_qsearch = depth <= 0;
   const i32 static_eval = eval(pos);
 
+  if (!in_check && static_eval - 128 * depth * (depth > 0) >= beta) {
+    return static_eval;
+  }
+
   if (depth < -3) {
     return static_eval;
   }
 
   if (in_qsearch && static_eval > alpha) {
-    if (static_eval >= beta) {
-      return static_eval;
-    }
     alpha = static_eval;
   }
 


### PR DESCRIPTION
I am basically a tester here.
Initial implementation by Gedas, size optimization by A_randomnoob | Sirius

Score of 4k_d vs 4k_m: 225 - 167 - 487  [0.533] 879
...      4k_d playing White: 143 - 63 - 232  [0.591] 438
...      4k_d playing Black: 82 - 104 - 255  [0.475] 441
...      White vs Black: 247 - 145 - 487  [0.558] 879
Elo difference: 23.0 +/- 15.3, LOS: 99.8 %, DrawRatio: 55.4 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted